### PR TITLE
Replace a glibcxx assertion with standard assert

### DIFF
--- a/dirty_zipfian_int_distribution.h
+++ b/dirty_zipfian_int_distribution.h
@@ -127,7 +127,7 @@ public:
     : _M_a(__a), _M_b(__b), _M_theta(__theta), _M_zeta(__zeta),
     _M_zeta2theta(zeta(2, __theta))
     {
-      __glibcxx_assert(_M_a <= _M_b && _M_theta > 0.0 && _M_theta < 1.0);
+      assert(_M_a <= _M_b && _M_theta > 0.0 && _M_theta < 1.0);
     }
 
     result_type	a() const { return _M_a; }


### PR DESCRIPTION
This is a truly trivial fix I applied while getting odgi to build with clang and libc++ on my machine today (see also https://github.com/pangenome/odgi/pull/350). I'm not aware of a special reason to use `__glibcxx_assert` here (could be missing something, though!), and it seems to not be available in libstdc++, so replacing it with a standard `assert` made things work for me.